### PR TITLE
HTTPS not required

### DIFF
--- a/pages/guides/3rdparty/panels.mdx
+++ b/pages/guides/3rdparty/panels.mdx
@@ -2,8 +2,5 @@ import { Callout } from 'nextra/components'
 
 ## Panels
 
-<Callout type="warning" emoji="⚠️">
-  [iOS requires HTTPS for remote connections](https://www.cnet.com/news/privacy/ios-apps-will-require-secure-https-connections-by-2017/). That means if you want to access your Kavita instance remotely you need to setup a reverse proxy and use SSL. 
-</Callout>
-
 You can read how to connect Panels to Kavita on the [Panels documentation site](https://guides.panels.app/opds/kavita/).
+


### PR DESCRIPTION
Feel free to toss this if I am wrong, but pretty sure iOS or Panels one made it so that you can use HTTP. I’ve been using it for a long time, and found references on the Discord of at least one other person getting it to work with HTTP only. 

I know that it is kind of a barrier for people who don’t know how to set up a certificate, but obviously is more secure if they do, so I don’t know if you might want to keep it, or change it to a recommendation.

I’m not sure what would be best, but I trust you to know what to do, just thought I would point it out. I also have no idea what I am doing with this, so hopefully I make sense and did everything correctly.