### PR TITLE
fix: link to KOReader on kavita dedicated and typo in 3rdparty meta.js

### DIFF
--- a/pages/guides/3rdparty/_meta.js
+++ b/pages/guides/3rdparty/_meta.js
@@ -1,7 +1,7 @@
 export default {
 	"aidoku": "Aidoku",
 	"cdisplayex": "CDisplayEX",
-	"kavita-dedicated": "Dedciated Kavita Apps",
+	"kavita-dedicated": "Dedicated Kavita Apps",
 	"koreader": "KOReader",
 	"mylar": "Mylar",
 	"panels": "Panels",

--- a/pages/guides/3rdparty/kavita-dedicated.mdx
+++ b/pages/guides/3rdparty/kavita-dedicated.mdx
@@ -25,5 +25,5 @@ Download [here](https://github.com/0xGingi/kavita-discord-reader)
 ### Kamare
 kamare is a manga reader plugin for KOReader that connects to Kavita.
 
-This [KOReader](/koreader) plugin provides a seamless way to read manga from Kavita without going through OPDS, featuring a custom renderer that also supports long-strip formats commonly used in manhwa.
+This [KOReader](../../guides/3rdparty/koreader) plugin provides a seamless way to read manga from Kavita without going through OPDS, featuring a custom renderer that also supports long-strip formats commonly used in manhwa.
 Download [here](https://github.com/fpammer/kamare.koplugin)


### PR DESCRIPTION
The link for KOReader on the Kavita Dedicated Apps page didn't path properly. Typo in 3rdparty _meta.js Dedciated should be Dedicated.