### PR TITLE
Update yomu.mdx: change to paid

### DIFF
--- a/pages/guides/3rdparty/yomu.mdx
+++ b/pages/guides/3rdparty/yomu.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components'
 
 # Yomu
 
-[Yomu](https://yomureader.app/) is a free native manga, webtoon, and manhwa reader for iPhone, iPad, and Mac with **built-in Kavita support** — no separate extension or repository required.
+[Yomu](https://yomureader.app/) is a paid(subscription/one-time) native manga, webtoon, and manhwa reader for iPhone, iPad, and Mac with **built-in Kavita support** — no separate extension or repository required.
 
 ## Installation
 


### PR DESCRIPTION
Yomu as of now requires a subscription or a one time payment to unlock Kavita syncing and other features. Change from Free to Paid to make sure the Kavita documentation states this accurately