### PR TITLE
Add Turnleaf to the Kavita dedicated apps wiki

### DIFF
--- a/pages/guides/3rdparty/kavita-dedicated.mdx
+++ b/pages/guides/3rdparty/kavita-dedicated.mdx
@@ -15,6 +15,16 @@ A dedicated cross-platform Kavita client featuring offline reading with seamless
 Works on mobile, desktop, and web.
 Download [here](https://github.com/rodonisi/kover)
 
+### Turnleaf
+
+Turnleaf is a dedicated offline-first mobile EPUB reader for Kavita. It connects directly to your Kavita server, lets you browse your library, download books for reliable offline reading, and sync reading progress back to Kavita so you can resume across devices. It focuses exclusively on conventional text-based EPUBs, with paginated reading and reader controls designed for a calm, minimal experience.
+
+Turnleaf is currently built and tested on Android only. It is a Capacitor wrapper around a Svelte app, so the iOS project should be buildable for anyone with Xcode available, but I have not personally verified an iOS build. It does not support manga, comics, PDFs, audiobooks, magazines, or other non-EPUB Kavita media types.
+
+PRs and forks are welcome.
+
+Download [here](https://github.com/sgerner/turnleaf/releases/latest)
+
 ### Kamigura
 A third-party Android client for Kavita, designed for self-scanned manga libraries and tablet-first reading.
 Download [here](https://github.com/KamiguraApp/Kamigura)


### PR DESCRIPTION
Adds Turnleaf to the Kavita dedicated apps wiki page.

- Describes Turnleaf as an offline-first mobile EPUB reader for Kavita
- Notes Android as the only currently tested platform
- Calls out the Capacitor + Svelte architecture and the unverified-but-buildable iOS scaffold
- Explicitly lists unsupported Kavita media types
- Invites PRs and forks
