### PR TITLE
Add cbzit to External Tools

### DIFF
--- a/pages/guides/external-tools/_meta.js
+++ b/pages/guides/external-tools/_meta.js
@@ -3,6 +3,7 @@ export default {
 	"komf": "Komf",
 	"comictagger": "ComicTagger",
 	"epub2cbz": "Epub to CBZ",
+	"cbzit": "cbzit",
 	"calibre": "Calibre",
 	"sigil": "Sigil",
 	"obsidian-importer": "Obsidian",

--- a/pages/guides/external-tools/cbzit.mdx
+++ b/pages/guides/external-tools/cbzit.mdx
@@ -1,0 +1,10 @@
+import { Callout } from 'nextra/components'
+
+## [cbzit](https://github.com/mate2/cbzit)
+cbzit turns folders of manga/comic page images into cleanly-named .cbz archives. It scans the folder, guesses the structure (series, volumes, chapters, language, titles), prints a dry-run report of exactly what it would build, and only writes once you confirm — your originals are never touched.
+* Smart bottom-up structure detection: series, volumes, chapters, page order, language tags and titles parsed from messy real-world folder names.
+* Dry-run report first — every archive name and page count is shown before a single byte is written.
+* Lossless & safe: duplicate chapters are kept as separate entries, page-name collisions are renumbered, and anything ambiguous becomes a visible warning instead of a silent wrong guess.
+* `merge` subcommand: consolidate a pile of chapter .cbz files into per-volume .cbz files, with a size guard.
+* Sort-safe, zero-padded naming so a folder's alphabetical order always matches reading order.
+* Cross-platform Node.js CLI — run it with `npx cbzit ./my-folder`, no install needed.


### PR DESCRIPTION
Adds **cbzit** to the External Tools guide.

[cbzit](https://github.com/mate2/cbzit) is an open-source (MIT) Node.js CLI that turns folders of manga/comic page images into cleanly-named `.cbz` archives: it detects the structure (series / volumes / chapters / language / titles) bottom-up, shows a dry-run report before writing anything, and never touches the original files. It also has a `merge` subcommand to consolidate chapter `.cbz` files into per-volume archives.

It complements the CBZ tooling already listed here (epub2cbz, ComicTagger, CBZ Cover Manager…) by covering the "loose folders of page images → clean CBZ" step. Added `cbzit.mdx` (mirroring the style of the existing entries) and registered it in `_meta.js` next to Epub to CBZ.