### PR TITLE
Add justRead as an OPDS-compatible iOS client

### DIFF
--- a/pages/guides/3rdparty/_meta.js
+++ b/pages/guides/3rdparty/_meta.js
@@ -1,6 +1,7 @@
 export default {
 	"aidoku": "Aidoku",
 	"cdisplayex": "CDisplayEX",
+	"justread": "justRead",
 	"kavita-dedicated": "Dedicated Kavita Apps",
 	"komic": "Komic",
 	"koreader": "KOReader",

--- a/pages/guides/3rdparty/justread.mdx
+++ b/pages/guides/3rdparty/justread.mdx
@@ -1,0 +1,17 @@
+import { Callout } from 'nextra/components'
+
+## justRead
+
+[justRead](https://justread.app) is a native EPUB, PDF, and audiobook reader for iPhone and iPad. It connects to Kavita through the standard OPDS catalog (no dedicated API integration), so you get catalog browsing, server-side search, and EPUB downloads, but no reading-progress sync back to Kavita.
+
+<Callout type="warning" emoji="⚠️">
+  [iOS requires HTTPS for remote connections](https://www.cnet.com/news/privacy/ios-apps-will-require-secure-https-connections-by-2017/). If you want to reach your Kavita instance remotely, set up a reverse proxy with SSL first.
+</Callout>
+
+### Setup
+
+1. In Kavita, open **User Settings → OPDS** and copy your OPDS URL (see the [OPDS guide](../features/opds.mdx) for details).
+2. In justRead, go to **Library → Add OPDS Server** and paste the URL.
+3. Browse and download EPUBs from your Kavita library directly in justRead.
+
+Only EPUB downloads are supported (justRead does not read comic/manga formats), so this integration is best suited for Kavita libraries that include text books alongside comics.

--- a/pages/guides/features/opds.mdx
+++ b/pages/guides/features/opds.mdx
@@ -53,6 +53,7 @@ Kavita also encodes reading progress directly into the title (since metadata sup
 | Chunky    |  ✓   |    ✓    |  ✗   |       ✓       |      ✗       |
 | Panels    |  ✓   |    ✓    |  ✗   |       ✓       |      ✗       |
 | Yomu      |  ✓   |    ✗    |  ✓   |       ✗       |      ✗       |
+| [justRead](../../guides/3rdparty/justread.mdx) |  ✓   |    ✗    |  ✓   |       ✗       |      ✗       |
 | [Paperback](../../guides/3rdparty/paperback.mdx) | ✗  |     ✗    |  ✗    |        ✓**       |     ✓       |
 | [Aidoku](../../guides/3rdparty/aidoku.mdx) | ✗  |     ✗    |  ✗    |        ✓**       |     ✓       |
 


### PR DESCRIPTION
justRead is a native iOS/iPadOS EPUB, PDF, and audiobook reader that connects to Kavita via the standard OPDS catalog (browsing, search, EPUB download). It doesn't use Kavita's dedicated REST API or OPDS-PS, and it doesn't read comic/manga formats, so it's a fit for Kavita libraries that include EPUB text books.

Adds:
- A row to the iOS OPDS-capable-clients table in guides/features/opds.mdx
- A short setup guide at guides/3rdparty/justread.mdx, modeled on the existing panels.mdx page
- The _meta.js entry

App Store: https://apps.apple.com/us/app/epub-reader-justread-app/id6757948605
Website: https://justread.app